### PR TITLE
fix: replace hardcoded version with env!("CARGO_PKG_VERSION") for con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.0.2] - 2025-07-31 |X| XX-XX-XXXX
+
+- [X] [\[IMPROVEMENT-001\] Centralize Version Info with CARGO_PKG_VERSION](https://github.com/rustisan/rustisan-core/issues/2)
+- 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustisan"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["Rustisan Contributors"]
 description = "Command-line interface for the Rustisan web framework"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod rustisan_core {
     pub fn init_logging() {
         // Mock implementation
     }
-    pub const VERSION: &str = "0.1.1";
+    pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 }
 
 use rustisan_core::{init_logging, VERSION};


### PR DESCRIPTION
…sistency

The application version was hardcoded in the source code, which could lead to inconsistencies between the binary and the Cargo.toml version. This commit replaces the hardcoded version string with env!("CARGO_PKG_VERSION") to ensure the version in the binary always matches the declared package version.

[[IMPROVEMENT-001] Centralize Version Info with CARGO_PKG_VERSION](https://github.com/rustisan/rustisan/issues/3)