### PR TITLE
Refactor utils.rs into dedicated modules: file, process, text, and env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## [0.0.2] - 2025-07-31 |X| XX-XX-XXXX
 
 - [X] [\[IMPROVEMENT-001\] Centralize Version Info with CARGO_PKG_VERSION](https://github.com/rustisan/rustisan-core/issues/2)
-- 
+- [\[Task-002\]  Benefits of the reorganization: #4
+](https://github.com/rustisan/rustisan/issues/4)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustisan"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1392,6 +1392,7 @@ dependencies = [
  "flate2",
  "handlebars",
  "indicatif",
+ "log",
  "pathdiff",
  "predicates",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pathdiff = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Environment variables
-dotenvy = "0.15"
+dotenvy = "0.15.7"
 
 # HTTP client for downloading
 reqwest = { version = "0.11", features = ["json", "stream"] }
@@ -70,6 +70,7 @@ base64 = "0.22"
 
 # UUID generation
 uuid = { version = "1.0", features = ["v4"] }
+log = "0.4.27"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Laravel-inspired web framework for Rust**
 
-[![Version](https://img.shields.io/badge/version-0.0.1-blue.svg)](https://github.com/rustisan/rustisan)
+[![Version](https://img.shields.io/badge/version-0.0.2-blue.svg)](https://github.com/rustisan/rustisan)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -99,8 +99,8 @@ async fn cache_configuration() -> Result<()> {
     let mut cached_config = std::collections::HashMap::new();
 
     for config_file in &config_files {
-        if std::path::Path::new(config_file).exists() {
-            let content = std::fs::read_to_string(config_file)?;
+        if CommandUtils::file_exists(config_file) {
+            let content = CommandUtils::read_file(config_file)?;
             match toml::from_str::<toml::Value>(&content) {
                 Ok(value) => {
                     let key = std::path::Path::new(config_file)
@@ -121,7 +121,7 @@ async fn cache_configuration() -> Result<()> {
 
     // Write cached configuration
     let cache_data = serde_json::to_string_pretty(&cached_config)?;
-    std::fs::write("bootstrap/cache/config.json", cache_data)?;
+    CommandUtils::write_file("bootstrap/cache/config.json", &cache_data)?;
 
     Ok(())
 }
@@ -192,15 +192,17 @@ async fn copy_to_output(output_dir: &str, profile: &str) -> Result<()> {
     let binary_src = format!("target/{}/rustisan", profile);
     let binary_dst = output_path.join("rustisan");
 
-    if std::path::Path::new(&binary_src).exists() {
-        std::fs::copy(&binary_src, &binary_dst)?;
+    if CommandUtils::file_exists(&binary_src) {
+        use crate::utils::FileUtils;
+        FileUtils::copy_file(&binary_src, &binary_dst)?;
     }
 
     // Copy configuration cache
     let config_cache = "bootstrap/cache/config.json";
-    if std::path::Path::new(config_cache).exists() {
+    if CommandUtils::file_exists(config_cache) {
         let cache_dst = output_path.join("config.json");
-        std::fs::copy(config_cache, cache_dst)?;
+        use crate::utils::FileUtils;
+        FileUtils::copy_file(config_cache, cache_dst)?;
     }
 
     // Copy public assets
@@ -232,7 +234,8 @@ fn copy_directory(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
                 CommandUtils::ensure_directory(parent)?;
             }
 
-            std::fs::copy(path, dst_path)?;
+            use crate::utils::FileUtils;
+            FileUtils::copy_file(path, dst_path)?;
         }
     }
 

--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -1,4 +1,4 @@
-//! Make commands for generating application components
+    //! Make commands for generating application components
 //!
 //! This module handles all the `rustisan make:*` commands for generating
 //! controllers, models, migrations, and other application components.
@@ -100,7 +100,7 @@ async fn make_controller(name: String, resource: bool, api: bool, model: Option<
         .join(format!("{}.rs", CommandUtils::to_snake_case(&name)));
 
     CommandUtils::ensure_directory(file_path.parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     // Update mod.rs
     update_module_file("src/controllers", &name)?;
@@ -184,7 +184,7 @@ impl Migration for {} {{
     // Write to file
     let file_path = format!("database/migrations/{}.rs", migration_name);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Migration created: {}", file_path));
 
@@ -275,7 +275,7 @@ impl {}Resource {{
 
     let file_path = format!("src/resources/{}.rs", snake_case);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Resource {} created successfully!", name.cyan().bold()));
 
@@ -314,7 +314,7 @@ impl {}Seeder {{
 
     let file_path = format!("database/seeders/{}.rs", snake_case);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Seeder {} created successfully!", name.cyan().bold()));
 
@@ -358,7 +358,7 @@ impl {}Factory {{
 
     let file_path = format!("database/factories/{}.rs", snake_case);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Factory {} created successfully!", name.cyan().bold()));
 
@@ -399,7 +399,7 @@ impl {}Command {{
 
     let file_path = format!("src/commands/{}.rs", snake_case);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Command {} created successfully!", name.cyan().bold()));
 
@@ -477,7 +477,7 @@ impl {}Job {{
 
     let file_path = format!("src/jobs/{}.rs", snake_case);
     CommandUtils::ensure_directory(&std::path::Path::new(&file_path).parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Job {} created successfully!", name.cyan().bold()));
 
@@ -557,7 +557,7 @@ pub trait {} {{
         .join(format!("{}.rs", CommandUtils::to_snake_case(&name)));
 
     CommandUtils::ensure_directory(file_path.parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Trait {} created successfully!", name.cyan().bold()));
 
@@ -601,7 +601,7 @@ async fn make_test(name: String, unit: bool, integration: bool) -> Result<()> {
         .join(format!("{}.rs", CommandUtils::to_snake_case(&name)));
 
     CommandUtils::ensure_directory(file_path.parent().unwrap())?;
-    std::fs::write(&file_path, content)?;
+    CommandUtils::write_file(&file_path, &content)?;
 
     CommandUtils::success(&format!("Test {} created successfully!", name.cyan().bold()));
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,7 +29,7 @@ pub use crate::{
 
 use anyhow::Result;
 use colored::*;
-use std::process::Command;
+use crate::utils::{FileUtils, ProcessUtils, TextUtils};
 
 /// Common utilities for all commands
 pub struct CommandUtils;
@@ -51,16 +51,7 @@ impl CommandUtils {
 
     /// Execute a shell command
     pub fn execute_command(cmd: &str, args: &[&str]) -> Result<()> {
-        let output = Command::new(cmd)
-            .args(args)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Command failed: {}", stderr);
-        }
-
-        Ok(())
+        ProcessUtils::execute_or_fail(cmd, args)
     }
 
     /// Print success message
@@ -85,35 +76,41 @@ impl CommandUtils {
 
     /// Create directory if it doesn't exist
     pub fn ensure_directory(path: &std::path::Path) -> Result<()> {
-        if !path.exists() {
-            std::fs::create_dir_all(path)?;
-        }
-        Ok(())
+        FileUtils::ensure_dir(path)
     }
 
     /// Convert string to snake_case
     pub fn to_snake_case(input: &str) -> String {
-        let mut result = String::new();
-        for (i, ch) in input.chars().enumerate() {
-            if i > 0 && ch.is_uppercase() {
-                result.push('_');
-            }
-            result.push(ch.to_lowercase().next().unwrap_or(ch));
-        }
-        result
+        TextUtils::to_snake_case(input)
     }
 
     /// Convert string to PascalCase
     pub fn to_pascal_case(input: &str) -> String {
-        input
-            .split('_')
-            .map(|word| {
-                let mut chars = word.chars();
-                match chars.next() {
-                    None => String::new(),
-                    Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str(),
-                }
-            })
-            .collect()
+        TextUtils::to_pascal_case(input)
+    }
+
+    /// Convert string to camelCase
+    pub fn to_camel_case(input: &str) -> String {
+        TextUtils::to_camel_case(input)
+    }
+
+    /// Check if a command exists in PATH
+    pub fn command_exists(command: &str) -> bool {
+        ProcessUtils::command_exists(command)
+    }
+
+    /// Check if a file exists
+    pub fn file_exists<P: AsRef<std::path::Path>>(path: P) -> bool {
+        FileUtils::exists(path)
+    }
+
+    /// Write content to a file
+    pub fn write_file<P: AsRef<std::path::Path>>(path: P, content: &str) -> Result<()> {
+        FileUtils::write_file(path, content)
+    }
+
+    /// Read file content as string
+    pub fn read_file<P: AsRef<std::path::Path>>(path: P) -> Result<String> {
+        FileUtils::read_file(path)
     }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-
+use crate::utils::env::set_var;
 use super::CommandUtils;
 
 /// Handle the serve command
@@ -18,11 +18,9 @@ pub async fn handle(host: String, port: u16, env: String, reload: bool) -> Resul
     CommandUtils::info(&format!("Starting Rustisan development server on {}:{}...", host, port));
 
     // Set environment variables
-    unsafe {
-        std::env::set_var("APP_ENV", &env);
-        std::env::set_var("SERVER_HOST", &host);
-        std::env::set_var("SERVER_PORT", &port.to_string());
-    }
+    set_var("APP_ENV", &env);
+    set_var("SERVER_HOST", &host);
+    set_var("SERVER_PORT", &port.to_string());
 
     if reload {
         start_with_hot_reload(host, port, env).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod generators;
 mod utils;
 
 use commands::*;
+use log::debug;
 
 /// Rustisan CLI - A Laravel-inspired web framework for Rust
 #[derive(Parser)]
@@ -438,7 +439,7 @@ pub enum ConfigCommands {
     Show,
     /// Get a specific configuration value
     Get {
-        /// Configuration key (e.g., app.name, database.default)
+            /// Configuration key (e.g., app.name, database.default)
         key: String,
     },
     /// Set configuration value
@@ -502,7 +503,6 @@ pub enum DevCommands {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-
     // Initialize logging based on verbosity
     if !cli.quiet {
         init_logging();

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -1,0 +1,10 @@
+use std::ffi::OsStr;
+
+/// Safe wrapper around unsafe set_var in custom std
+#[inline]
+pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
+    // SAFETY: We ensure this is only called during single-threaded startup
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,8 @@
+pub mod env;
+pub mod file;
+pub mod process;
+pub mod text;
+
+pub use file::FileUtils;
+pub use process::ProcessUtils;
+pub use text::TextUtils;

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,0 +1,108 @@
+//! Process utilities for the Rustisan CLI
+//!
+//! This module provides common process and command execution utilities.
+
+use anyhow::Result;
+use std::process::Command;
+
+/// Process utilities
+pub struct ProcessUtils;
+
+impl ProcessUtils {
+    /// Check if a command exists in PATH
+    pub fn command_exists(command: &str) -> bool {
+        Command::new("which")
+            .arg(command)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Execute a command and return success status
+    pub fn execute(command: &str, args: &[&str]) -> Result<bool> {
+        let output = Command::new(command)
+            .args(args)
+            .output()?;
+
+        Ok(output.status.success())
+    }
+
+    /// Execute a command and capture output
+    pub fn execute_with_output(command: &str, args: &[&str]) -> Result<(bool, String, String)> {
+        let output = Command::new(command)
+            .args(args)
+            .output()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        Ok((output.status.success(), stdout, stderr))
+    }
+
+    /// Execute a command and return Result based on success
+    pub fn execute_or_fail(command: &str, args: &[&str]) -> Result<()> {
+        let output = Command::new(command)
+            .args(args)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Command '{}' failed: {}", command, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Execute a command in a specific working directory
+    pub fn execute_in_dir<P: AsRef<std::path::Path>>(
+        command: &str,
+        args: &[&str],
+        working_dir: P
+    ) -> Result<bool> {
+        let output = Command::new(command)
+            .args(args)
+            .current_dir(working_dir)
+            .output()?;
+
+        Ok(output.status.success())
+    }
+
+    /// Execute a command and get the exit code
+    pub fn execute_with_code(command: &str, args: &[&str]) -> Result<i32> {
+        let output = Command::new(command)
+            .args(args)
+            .output()?;
+
+        Ok(output.status.code().unwrap_or(-1))
+    }
+
+    /// Check if we're running on Windows
+    pub fn is_windows() -> bool {
+        cfg!(target_os = "windows")
+    }
+
+    /// Check if we're running on macOS
+    pub fn is_macos() -> bool {
+        cfg!(target_os = "macos")
+    }
+
+    /// Check if we're running on Linux
+    pub fn is_linux() -> bool {
+        cfg!(target_os = "linux")
+    }
+
+    /// Get the appropriate shell command for the current OS
+    pub fn get_shell_command() -> (&'static str, &'static str) {
+        if Self::is_windows() {
+            ("cmd", "/C")
+        } else {
+            ("sh", "-c")
+        }
+    }
+
+    /// Execute a shell command
+    pub fn execute_shell(command: &str) -> Result<bool> {
+        let (shell, flag) = Self::get_shell_command();
+        Self::execute(shell, &[flag, command])
+    }
+}

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,0 +1,211 @@
+//! Text utilities for the Rustisan CLI
+//!
+//! This module provides common text manipulation and formatting utilities.
+
+/// Text utilities
+pub struct TextUtils;
+
+impl TextUtils {
+    /// Capitalize first letter
+    pub fn capitalize(s: &str) -> String {
+        let mut chars = s.chars();
+        match chars.next() {
+            None => String::new(),
+            Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str(),
+        }
+    }
+
+    /// Convert string to snake_case
+    pub fn to_snake_case(input: &str) -> String {
+        let mut result = String::new();
+        for (i, ch) in input.chars().enumerate() {
+            if i > 0 && ch.is_uppercase() {
+                result.push('_');
+            }
+            result.push(ch.to_lowercase().next().unwrap_or(ch));
+        }
+        result
+    }
+
+    /// Convert string to PascalCase
+    pub fn to_pascal_case(input: &str) -> String {
+        input
+            .split('_')
+            .map(|word| {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str(),
+                }
+            })
+            .collect()
+    }
+
+    /// Convert string to camelCase
+    pub fn to_camel_case(input: &str) -> String {
+        let pascal = Self::to_pascal_case(input);
+        let mut chars = pascal.chars();
+        match chars.next() {
+            None => String::new(),
+            Some(first) => first.to_lowercase().collect::<String>() + &chars.as_str(),
+        }
+    }
+
+    /// Convert string to kebab-case
+    pub fn to_kebab_case(input: &str) -> String {
+        Self::to_snake_case(input).replace('_', "-")
+    }
+
+    /// Pluralize a word (simple English rules)
+    pub fn pluralize(word: &str) -> String {
+        if word.is_empty() {
+            return word.to_string();
+        }
+
+        let lower = word.to_lowercase();
+        if lower.ends_with('s') || lower.ends_with("sh") || lower.ends_with("ch")
+           || lower.ends_with('x') || lower.ends_with('z') {
+            format!("{}es", word)
+        } else if lower.ends_with('y') && !lower.ends_with("ay") && !lower.ends_with("ey")
+                 && !lower.ends_with("iy") && !lower.ends_with("oy") && !lower.ends_with("uy") {
+            format!("{}ies", &word[..word.len()-1])
+        } else if lower.ends_with('f') {
+            format!("{}ves", &word[..word.len()-1])
+        } else if lower.ends_with("fe") {
+            format!("{}ves", &word[..word.len()-2])
+        } else {
+            format!("{}s", word)
+        }
+    }
+
+    /// Singularize a word (simple English rules)
+    pub fn singularize(word: &str) -> String {
+        if word.is_empty() {
+            return word.to_string();
+        }
+
+        let lower = word.to_lowercase();
+        if lower.ends_with("ies") {
+            format!("{}y", &word[..word.len()-3])
+        } else if lower.ends_with("ves") {
+            if word.len() > 4 && &lower[word.len()-4..word.len()-3] == "l" {
+                format!("{}f", &word[..word.len()-3])
+            } else {
+                format!("{}fe", &word[..word.len()-3])
+            }
+        } else if lower.ends_with("es") && word.len() > 2 {
+            let before_es = &lower[word.len()-3..word.len()-2];
+            if before_es == "s" || before_es == "x" || before_es == "z" {
+                word[..word.len()-2].to_string()
+            } else if word.len() > 3 && (&lower[word.len()-4..word.len()-2] == "sh" || &lower[word.len()-4..word.len()-2] == "ch") {
+                word[..word.len()-2].to_string()
+            } else {
+                word[..word.len()-1].to_string()
+            }
+        } else if lower.ends_with('s') && word.len() > 1 {
+            word[..word.len()-1].to_string()
+        } else {
+            word.to_string()
+        }
+    }
+
+    /// Truncate text to a specified length with ellipsis
+    pub fn truncate(text: &str, max_length: usize) -> String {
+        if text.len() <= max_length {
+            text.to_string()
+        } else if max_length <= 3 {
+            "...".to_string()
+        } else {
+            format!("{}...", &text[..max_length-3])
+        }
+    }
+
+    /// Pad text to the left with spaces
+    pub fn pad_left(text: &str, width: usize) -> String {
+        format!("{:>width$}", text, width = width)
+    }
+
+    /// Pad text to the right with spaces
+    pub fn pad_right(text: &str, width: usize) -> String {
+        format!("{:<width$}", text, width = width)
+    }
+
+    /// Center text within a specified width
+    pub fn center(text: &str, width: usize) -> String {
+        format!("{:^width$}", text, width = width)
+    }
+
+    /// Remove extra whitespace and normalize spacing
+    pub fn normalize_whitespace(text: &str) -> String {
+        text.split_whitespace().collect::<Vec<&str>>().join(" ")
+    }
+
+    /// Check if a string is a valid identifier (starts with letter/underscore, contains only alphanumeric/underscore)
+    pub fn is_valid_identifier(s: &str) -> bool {
+        if s.is_empty() {
+            return false;
+        }
+
+        let mut chars = s.chars();
+        let first = chars.next().unwrap();
+
+        if !first.is_alphabetic() && first != '_' {
+            return false;
+        }
+
+        chars.all(|c| c.is_alphanumeric() || c == '_')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(TextUtils::capitalize("hello"), "Hello");
+        assert_eq!(TextUtils::capitalize(""), "");
+        assert_eq!(TextUtils::capitalize("a"), "A");
+    }
+
+    #[test]
+    fn test_to_snake_case() {
+        assert_eq!(TextUtils::to_snake_case("HelloWorld"), "hello_world");
+        assert_eq!(TextUtils::to_snake_case("hello"), "hello");
+        assert_eq!(TextUtils::to_snake_case("HTTPSConnection"), "h_t_t_p_s_connection");
+    }
+
+    #[test]
+    fn test_to_pascal_case() {
+        assert_eq!(TextUtils::to_pascal_case("hello_world"), "HelloWorld");
+        assert_eq!(TextUtils::to_pascal_case("hello"), "Hello");
+        assert_eq!(TextUtils::to_pascal_case("user_profile_image"), "UserProfileImage");
+    }
+
+    #[test]
+    fn test_pluralize() {
+        assert_eq!(TextUtils::pluralize("cat"), "cats");
+        assert_eq!(TextUtils::pluralize("box"), "boxes");
+        assert_eq!(TextUtils::pluralize("city"), "cities");
+        assert_eq!(TextUtils::pluralize("leaf"), "leaves");
+    }
+
+    #[test]
+    fn test_singularize() {
+        assert_eq!(TextUtils::singularize("cats"), "cat");
+        assert_eq!(TextUtils::singularize("boxes"), "box");
+        assert_eq!(TextUtils::singularize("cities"), "city");
+        assert_eq!(TextUtils::singularize("leaves"), "leave");
+    }
+
+    #[test]
+    fn test_is_valid_identifier() {
+        assert!(TextUtils::is_valid_identifier("hello"));
+        assert!(TextUtils::is_valid_identifier("_private"));
+        assert!(TextUtils::is_valid_identifier("user_name"));
+        assert!(TextUtils::is_valid_identifier("User123"));
+        assert!(!TextUtils::is_valid_identifier("123user"));
+        assert!(!TextUtils::is_valid_identifier("user-name"));
+        assert!(!TextUtils::is_valid_identifier(""));
+    }
+}


### PR DESCRIPTION
- Split the large utils.rs file into smaller, focused modules for better modularity:
  * file.rs      - FileUtils: file system operations
  * process.rs   - ProcessUtils: process and command operations
  * text.rs      - TextUtils: text manipulation and formatting
  * env.rs       - Environment variable utilities (kept separate)

- Updated utils mod.rs to export new modules and added re-exports for easy access

- Removed duplicated functions by consolidating code into appropriate modules

- Updated existing code to use the new utilities, improving code maintainability and clarity